### PR TITLE
117 unset filters and various other glitches

### DIFF
--- a/features/decide/create_missing_broadcast.feature
+++ b/features/decide/create_missing_broadcast.feature
@@ -58,8 +58,8 @@ Feature: Create missing records
     Given I am not logged in
     And I visit the decision page
     And there are no broadcasts in the database
-    Then no form but a message is there, telling me:
+    Then all form fields are disabled and there is a message telling me:
     """
-    If you log in, you can create new broadcasts
+    Log in to create new broadcasts
     """
 

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -217,8 +217,10 @@ Then(/^I(?: can)? see the "([^"]*)" menu item$/) do |label|
 end
 
 Given(/^I see a medium called "([^"]*)"$/) do |medium|
-  find('.ui.dropdown').click
-  expect(page).to have_text(medium)
+  within('.broadcast-search') do
+    find('.ui.dropdown').click
+    expect(page).to have_text(medium)
+  end
 end
 
 When(/^I click on the lock symbol next to "([^"]*)"$/) do |title|
@@ -747,10 +749,13 @@ When(/^I choose "([^"]*)" from the list of available media$/) do |medium|
   find('.item:not(.blank)', text: medium).click
 end
 
-Then(/^no form but a message is there, telling me:$/) do |string|
-  expect(page).not_to have_field('title')
-  expect(page).not_to have_field('description')
-  expect(page).to have_text(string)
+Then(/^all form fields are disabled and there is a message telling me:$/) do |string|
+  expect(page).to have_css('.broadcast-form.warning')
+  within('.broadcast-form.warning') do
+    expect(page).to have_css('.field.disabled')
+    expect(page).not_to have_css('.field:not(.disabled)')
+    expect(page).to have_text(string)
+  end
 end
 
 Given(/^there are no broadcasts in the database$/) do


### PR DESCRIPTION
close #117
along various other problems:
* errored post requests in /login route don't stop redirecting
* unset query param
* broken template below the broadcast form in /decide
* wrong help message if result set is empty in /decide
* missing 'my reviews' button in /invoice