### PR TITLE
353 pagination bug

### DIFF
--- a/backend/app/models/broadcast.rb
+++ b/backend/app/models/broadcast.rb
@@ -48,7 +48,7 @@ class Broadcast < ApplicationRecord
   end
 
   def self.search(query: nil, filter_params: nil, sort: nil, seed: nil, user: nil)
-    results = Broadcast.all.includes(:impressions)
+    results = Broadcast.all
     results = results.full_search(query) unless query.blank?
     if filter_params
       results = results.where(medium: filter_params[:medium]) unless filter_params[:medium].blank?

--- a/backend/app/models/broadcast.rb
+++ b/backend/app/models/broadcast.rb
@@ -62,7 +62,7 @@ class Broadcast < ApplicationRecord
 
   def self.review_filter(review_status, user)
     if review_status == 'reviewed'
-      evaluated(user).includes(:impressions)
+      evaluated(user)
     elsif review_status == 'unreviewed'
       unevaluated(user)
     end


### PR DESCRIPTION
close #353

This was probably the hardest to reproduce bug in my life so far. It only appears when:
* You search for a station
* and order randomly
* and use pagination
* and there is a broadcast in the result set with many stations (called troublemaker)
* and the troublemaker has some impressions
* and there are some more broadcasts in the result set

What happens is that the LEFT OUTER JOIN of impressions joins in the troublemaker more than just once. The pagination gets confused because it adds some duplicate `broadcast_id` to the IN clause. Every duplicate id in the IN-clause will reduce the final result set. That's the reason why we get less than 6 results.
