### PR TITLE
error page incase of unsuccessful request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ screenshots/
 notes.txt
 foreman.out
 .DS_Store
+*.tern-port

--- a/frontend/app/routes/broadcast.js
+++ b/frontend/app/routes/broadcast.js
@@ -2,12 +2,18 @@ import Ember from 'ember';
 import ResetScrollPositionMixin from 'frontend/mixins/reset-scroll-position';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(
-  AuthenticatedRouteMixin,
-  ResetScrollPositionMixin,
-  {
-    model(params) {
-      return this.get('store').findRecord('broadcast', params.broadcast_id);
+export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScrollPositionMixin, {
+  model(params) {
+    return this.get('store').findRecord('broadcast', params.broadcast_id);
+  },
+  actions: {
+    error(error) {
+      if (error.errors.isAny('status', '404')) {
+        this.transitionTo('/404'); // '404' gives a name error, why??
+      } else {
+        // Let the route above this handle the error.
+        return true;
+      }
     }
   }
-);
+});

--- a/frontend/app/routes/broadcast.js
+++ b/frontend/app/routes/broadcast.js
@@ -2,8 +2,12 @@ import Ember from 'ember';
 import ResetScrollPositionMixin from 'frontend/mixins/reset-scroll-position';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, ResetScrollPositionMixin, {
-  model(params) {
-    return this.get('store').findRecord('broadcast', params.broadcast_id);
+export default Ember.Route.extend(
+  AuthenticatedRouteMixin,
+  ResetScrollPositionMixin,
+  {
+    model(params) {
+      return this.get('store').findRecord('broadcast', params.broadcast_id);
+    }
   }
-});
+);

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -117,6 +117,11 @@ p {
   visibility: hidden;
 }
 
+i.frown {
+  font-size: 7em;
+  padding-top: 0.5em;
+}
+
 
 @media only screen and (max-width: 320px) {
   .pagination.dots {

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -117,12 +117,6 @@ p {
   visibility: hidden;
 }
 
-i.frown {
-  font-size: 7em;
-  padding-top: 0.5em;
-}
-
-
 @media only screen and (max-width: 320px) {
   .pagination.dots {
     display: none !important;

--- a/frontend/app/templates/404.hbs
+++ b/frontend/app/templates/404.hbs
@@ -1,2 +1,6 @@
-<div class="ui huge header">{{t '404.header'}} </div>
-<p>{{t '404.sub-header'}}</p>
+<div class="ui center aligned container">
+	<i class="massive meh icon"></i>
+	<div class="ui huge header">{{t '404.header'}} </div>
+	<p>{{t '404.sub-header'}}</p>
+	{{outline}}
+</div>

--- a/frontend/app/templates/error.hbs
+++ b/frontend/app/templates/error.hbs
@@ -1,5 +1,0 @@
-<div class="ui center aligned container">
-<i class="frown icon"></i>
-<div class="ui huge header">{{t '404.header'}} </div>
-<p>{{t '404.sub-header'}}</p>
-</div>

--- a/frontend/app/templates/error.hbs
+++ b/frontend/app/templates/error.hbs
@@ -1,0 +1,5 @@
+<div class="ui center aligned container">
+<i class="frown icon"></i>
+<div class="ui huge header">{{t '404.header'}} </div>
+<p>{{t '404.sub-header'}}</p>
+</div>

--- a/frontend/tests/acceptance/broadcast/404-error-test.js
+++ b/frontend/tests/acceptance/broadcast/404-error-test.js
@@ -1,4 +1,4 @@
-import { context, describe, it, beforeEach, afterEach } from 'mocha';
+import { context, describe, xit, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
@@ -48,7 +48,7 @@ describe('Acceptance | broadcast/ 404 error', function() {
         broadcastMock.fails({status: 404, response: {errors: {status: '404', name: ["broadcast not found"]}}});
       });
 
-      it('shows a 404 error page', function() {
+      xit('shows a 404 error page', function() {
         visit('/broadcast/' + broadcast.get('id'));
 
         return andThen(() => {

--- a/frontend/tests/acceptance/broadcast/404-error-test.js
+++ b/frontend/tests/acceptance/broadcast/404-error-test.js
@@ -1,4 +1,4 @@
-import { context, describe, xit, it, beforeEach, afterEach } from 'mocha';
+import { context, describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
@@ -12,9 +12,6 @@ describe('Acceptance | broadcast/ 404 error', function() {
     application = startApp();
     mockSetup();
     broadcastMock = mockFindRecord('broadcast');
-    broadcast = make('broadcast', {
-      title: 'This is the title'
-    })
   });
 
   afterEach(function() {
@@ -30,12 +27,15 @@ describe('Acceptance | broadcast/ 404 error', function() {
 
     context('backend route /broadcast/:broadcast_id', function() {
       beforeEach(function() {
+        broadcast = make('broadcast', {
+          title: 'This is the title'
+        })
         broadcastMock.returns({model: broadcast});
       });
 
 
       it('shows the broadcast page', function() {
-        visit('/broadcast/' + broadcast.get('id'));
+        visit('/broadcast/' + broadcastMock.get('id'));
 
         return andThen(() => {
           expect(find('.title.header').text()).to.have.string('This is the title');
@@ -45,11 +45,11 @@ describe('Acceptance | broadcast/ 404 error', function() {
 
     describe('HTTP 404 from backend', function() {
       beforeEach(function() {
-        broadcastMock.fails({status: 404, response: {errors: {status: '404', name: ["broadcast not found"]}}});
+        broadcastMock.fails({status: 404});
       });
 
-      xit('shows a 404 error page', function() {
-        visit('/broadcast/' + broadcast.get('id'));
+      it('shows a 404 error page', function() {
+        visit('/broadcast/' + broadcastMock.get('id'));
 
         return andThen(() => {
           expect(find('p').text()).to.have.string('We could not find that page');

--- a/frontend/tests/acceptance/broadcast/404-error-test.js
+++ b/frontend/tests/acceptance/broadcast/404-error-test.js
@@ -1,0 +1,60 @@
+import { context, describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import startApp from '../../helpers/start-app';
+import destroyApp from '../../helpers/destroy-app';
+import { make, mockSetup, mockTeardown, mockFindRecord } from 'ember-data-factory-guy';
+import { authenticateSession } from 'frontend/tests/helpers/ember-simple-auth';
+
+describe('Acceptance | broadcast/ 404 error', function() {
+  let application, broadcast, broadcastMock;
+
+  beforeEach(function() {
+    application = startApp();
+    mockSetup();
+    broadcastMock = mockFindRecord('broadcast');
+    broadcast = make('broadcast', {
+      title: 'This is the title'
+    })
+  });
+
+  afterEach(function() {
+    mockTeardown();
+    destroyApp(application);
+  });
+
+  context('logged in', function() {
+    beforeEach(function() {
+      const sessionData = {idToken : 1};
+      authenticateSession(application, sessionData);
+    });
+
+    context('backend route /broadcast/:broadcast_id', function() {
+      beforeEach(function() {
+        broadcastMock.returns({model: broadcast});
+      });
+
+
+      it('shows the broadcast page', function() {
+        visit('/broadcast/' + broadcast.get('id'));
+
+        return andThen(() => {
+          expect(find('.title.header').text()).to.have.string('This is the title');
+        });
+      });
+    });
+
+    describe('HTTP 404 from backend', function() {
+      beforeEach(function() {
+        broadcastMock.fails({status: 404, response: {errors: {status: '404', name: ["broadcast not found"]}}});
+      });
+
+      it('shows a 404 error page', function() {
+        visit('/broadcast/' + broadcast.get('id'));
+
+        return andThen(() => {
+          expect(find('p').text()).to.have.string('We could not find that page');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
closes #340 
When there is an error getting data from backend, render the error page

## problem with this approach
Incase of any error then this page will be rendered, it does not tell the user what the exact error was
For example when I visit 'My Broadcasts' I get the same error page

## GIF

![peek 2017-10-27 18-33](https://user-images.githubusercontent.com/584211/32112235-5cafeed4-bb45-11e7-8813-8515c6e12b0e.gif)
