### PR TITLE
Handle other  errors - other than 404

### DIFF
--- a/frontend/app/templates/error.hbs
+++ b/frontend/app/templates/error.hbs
@@ -1,0 +1,6 @@
+<div class="ui center aligned container">
+	<i class="massive meh icon"></i>
+	<div class="ui huge header">{{t 'error.header'}} </div>
+	<p>{{t 'error.sub-header'}}</p>
+	{{outline}}
+</div>

--- a/frontend/tests/acceptance/error-page-test.js
+++ b/frontend/tests/acceptance/error-page-test.js
@@ -2,11 +2,7 @@ import { context, describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import {
-  mockSetup,
-  mockTeardown,
-  mockFindRecord
-} from 'ember-data-factory-guy';
+import { mockSetup, mockTeardown, mockFindAll } from 'ember-data-factory-guy';
 import { authenticateSession } from 'frontend/tests/helpers/ember-simple-auth';
 
 describe('Acceptance | Errors', function() {
@@ -14,7 +10,7 @@ describe('Acceptance | Errors', function() {
   beforeEach(function() {
     application = startApp();
     mockSetup();
-    broadcastMock = mockFindRecord('broadcast');
+    broadcastMock = mockFindAll('broadcast');
   });
   afterEach(function() {
     mockTeardown();
@@ -33,7 +29,7 @@ describe('Acceptance | Errors', function() {
       });
 
       it('shows an error page', function() {
-        visit('/invoice');
+        visit('/find-broadcasts');
         return andThen(() => {
           expect(find('p').text()).to.have.string('Hm, something went wrong');
         });

--- a/frontend/tests/acceptance/error-page-test.js
+++ b/frontend/tests/acceptance/error-page-test.js
@@ -1,0 +1,43 @@
+import { context, describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+import {
+  mockSetup,
+  mockTeardown,
+  mockFindRecord
+} from 'ember-data-factory-guy';
+import { authenticateSession } from 'frontend/tests/helpers/ember-simple-auth';
+
+describe('Acceptance | Errors', function() {
+  let application, broadcastMock;
+  beforeEach(function() {
+    application = startApp();
+    mockSetup();
+    broadcastMock = mockFindRecord('broadcast');
+  });
+  afterEach(function() {
+    mockTeardown();
+    destroyApp(application);
+  });
+
+  context('logged in', function() {
+    beforeEach(function() {
+      const sessionData = { idToken: 1 };
+      authenticateSession(application, sessionData);
+    });
+
+    describe('HTTP 500 from backend', function() {
+      beforeEach(function() {
+        broadcastMock.fails({ status: 500 });
+      });
+
+      it('shows an error page', function() {
+        visit('/invoice');
+        return andThen(() => {
+          expect(find('p').text()).to.have.string('Hm, something went wrong');
+        });
+      });
+    });
+  });
+});

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -587,3 +587,7 @@ about-us:
 404:
   header: Ups..
   sub-header: Wir konnten die Seite nicht finden.
+
+error:
+  header: Ups..
+  sub-header: Hm, etwas ist schief gelaufen

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -560,3 +560,7 @@ about-us:
 404:
   header: Oops..
   sub-header: We could not find that page.
+
+error:
+  header: Oops..
+  sub-header: Hm, something went wrong


### PR DESCRIPTION
closes #379
## Done
- use error template that is rendered incase error is not caught by `404`

## Screenshot
![screenshot-2017-10-30 rundfunk-mitbestimmen](https://user-images.githubusercontent.com/584211/32177303-0c408460-bd9b-11e7-9a95-c99c80532ea5.png)

## GIF
![peek 2017-10-30 17-55](https://user-images.githubusercontent.com/584211/32177538-98e027d6-bd9b-11e7-88bd-8969bb4cb111.gif)

