### PR TITLE
Rename route /impressions to /votes

### DIFF
--- a/backend/app/controllers/impressions_controller.rb
+++ b/backend/app/controllers/impressions_controller.rb
@@ -22,7 +22,7 @@ class ImpressionsController < ApplicationController
     @impression.user = current_user # you can only create your own
 
     if @impression.save
-      render json: @impression, status: :created, location: @impression
+      render json: @impression, status: :created, location: vote_url(@impression)
     else
       render json: @impression.errors, status: :unprocessable_entity
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
   resources :formats, only: %i[index show]
   resources :topics, only: %i[index show]
   resources :broadcasts
-  resources :impressions
+
+  # see https://github.com/roschaefer/rundfunk-mitbestimmen/issues/419
+  resources :votes, controller: :impressions
+
   resources :users, only: :update
   resource  :users, only: :show
 

--- a/backend/spec/requests/impressions_spec.rb
+++ b/backend/spec/requests/impressions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Impressions', type: :request do
   end
 
   describe '*' do
-    let(:url) { '/impressions' } # as an example
+    let(:url) { '/votes' } # as an example
     let(:request) { get url, params: params, headers: headers }
     context 'legacy user without auth0_uid or location' do
       before { user }
@@ -47,8 +47,8 @@ RSpec.describe 'Impressions', type: :request do
     end
   end
 
-  describe 'GET /impressions' do
-    let(:action) { get '/impressions', params: params, headers: headers }
+  describe 'GET /votes' do
+    let(:action) { get '/votes', params: params, headers: headers }
     let(:impressions) { [positive_impression, neutral_impression] }
     subject do
       impressions
@@ -83,8 +83,8 @@ RSpec.describe 'Impressions', type: :request do
     end
   end
 
-  describe 'GET /impressions/:id' do
-    let(:action) { get "/impressions/#{impression.id}", params: params, headers: headers }
+  describe 'GET /votes/:id' do
+    let(:action) { get "/votes/#{impression.id}", params: params, headers: headers }
     let(:impression) { create(:impression, user: user) }
 
     subject do
@@ -113,8 +113,8 @@ RSpec.describe 'Impressions', type: :request do
     end
   end
 
-  describe 'POST /impressions' do
-    let(:action) { post '/impressions', params: params, headers: headers }
+  describe 'POST /votes' do
+    let(:action) { post '/votes', params: params, headers: headers }
 
     subject do
       action

--- a/frontend/app/adapters/application.js
+++ b/frontend/app/adapters/application.js
@@ -7,7 +7,12 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
   authorizer: 'authorizer:jwt',
   host: ENV.APP.BACKEND_URL,
   pathForType: function(type) {
-    return Ember.String.pluralize(Ember.String.underscore(type));
+    if (type === 'impression'){
+      // see https://github.com/roschaefer/rundfunk-mitbestimmen/issues/419
+      return 'votes';
+    } else {
+      return Ember.String.pluralize(Ember.String.underscore(type));
+    }
   },
   intl: Ember.inject.service(),
   headers: Ember.computed('intl.locale', function() {
@@ -15,5 +20,4 @@ export default JSONAPIAdapter.extend(DataAdapterMixin, {
       'locale': this.get('intl').get('locale'),
     };
   })
-
 });


### PR DESCRIPTION
It seems that /impressions is a common pattern of adblockers like UBlock
Origin. Renaming should fix the issue.

close #419