### PR TITLE
Opt-in rails-erd with environment variable ERD=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,27 +114,20 @@ git clone https://github.com/roschaefer/rundfunk-mitbestimmen.git
 ```
 
 ### Install dependencies and run migrations:
-1. Install `graphviz` that will be used to generate ER diagrams
-
-```sh
-OSX: brew install graphviz
-Ubuntu/Debian: sudo apt install graphviz
-
-```
-2. Install dependencies for full stack testing
+1. Install dependencies for full stack testing
 ```sh
 cd rundfunk-mitbestimmen
 bundle
 ```
 
-3. Install frontend dependencies
+2. Install frontend dependencies
 ```sh
 cd frontend
 yarn install
 bower install
 ```
 
-4. Install backend dependencies and setup the database
+3. Install backend dependencies and setup the database
 ```sh
 cd ../backend
 bundle
@@ -142,7 +135,7 @@ bin/rails db:create db:migrate
 cd ..
 ```
 
-5. If you want, you can create some seed data
+4. If you want, you can create some seed data
 ```
 cd backend
 bin/rails db:seed

--- a/backend/lib/tasks/auto_generate_diagram.rake
+++ b/backend/lib/tasks/auto_generate_diagram.rake
@@ -1,4 +1,4 @@
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
-RailsERD.load_tasks if Rails.env.development?
+RailsERD.load_tasks if Rails.env.development? && ENV['ERD']


### PR DESCRIPTION
fix #502

@FedericoEsparza could you have a look? The original plan was too complex. `rails-erd` does not crash during installation but during generation of the actual entity-relationship diagram. Thanks to that, we can simply have an opt-in with an environment variable.