### PR TITLE
Trying to fix flaky zlib Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 
 script:
   - cd frontend
-  - ember test
+  - BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=./cache ember test
   - cd -
   - cd backend
   - bundle exec brakeman -z


### PR DESCRIPTION
Disabling the tmp cache for `ember test` could be a solution, as we're
running two builds of the frontend at the same time in our travis ci
setup. 1. `foreman -f ProcfileTesting &` (send to the background) and 2.
`ember test`.
See
https://github.com/stefanpenner/broccoli-persistent-filter/issues/124