### PR TITLE
Avoid unnecessary geocode jobs

### DIFF
--- a/backend/app/jobs/geocode_user_job.rb
+++ b/backend/app/jobs/geocode_user_job.rb
@@ -3,6 +3,7 @@ class GeocodeUserJob < ApplicationJob
 
   def perform(auth0_uid, access_token = nil)
     return unless auth0_uid
+    return unless Geocoder.config[:ipstack][:api_key]
 
     user = User.find_by(auth0_uid: auth0_uid)
     return unless user

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
     # ignore
   end
 
-  # This method is used by a geocode_user_job YA ESTABA
+  # This method is used by a geocode_user_job
   def assign_location_attributes(geocoder_result)
     return unless geocoder_result
 

--- a/backend/config/initializers/geocoder.rb
+++ b/backend/config/initializers/geocoder.rb
@@ -8,10 +8,10 @@ Geocoder.configure(
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
   google: {
-    api_key: (ENV['GOOGLE_API_KEY'] || 'GOOGLE_API_KEY') # API key for geocoding service
+    api_key: Rails.env.test? ? 'GOOGLE_API_KEY' : ENV['GOOGLE_API_KEY'] # Lat/Long -> region & post code
   },
   ipstack: {
-    api_key: (ENV['IPSTACK_API_KEY'] || 'IPSTACK_API_KEY') # API key for geocoding service
+    api_key: Rails.env.test? ? 'IPSTACK_API_KEY' : ENV['IPSTACK_API_KEY'] # IP -> region & post code
   }
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys

--- a/backend/spec/jobs/geocode_user_job_spec.rb
+++ b/backend/spec/jobs/geocode_user_job_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe GeocodeUserJob, type: :job do
     it { expect { subject }.not_to raise_error }
   end
 
+  context 'ipstack API key' do
+    let(:auth0_uid) { 'whatever' }
+    before { create(:user, auth0_uid: auth0_uid) } # now we would run into a request
+
+    context 'missing' do
+      before { allow(Geocoder.config).to receive(:[]).with(:ipstack).and_return(api_key: nil) }
+      it { expect { subject }.not_to raise_error }
+    end
+  end
+
   context 'no user for auth0_uid' do
     let(:auth0_uid) { 'no_user_for_that_auth0_uid' }
     it { expect { subject }.not_to raise_error }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Fixes #882 

#### Motivation and Context
When you create users, e.g. when seeding the datbase, sidekiq starts to send geocode requests to ipstack over and over, because the API key is not `null` it is a placeholder string. The placeholder string is required by `vcr` to conceal sensitive data.

#### How Has This Been Tested?
With:
```sh
bin/rspec spec/jobs/geocode_user_job_spec.rb --format doc
```


#### Screenshots (if appropriate):

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes. -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
