### PR TITLE
Fix #882

### DIFF
--- a/backend/app/jobs/geocode_user_job.rb
+++ b/backend/app/jobs/geocode_user_job.rb
@@ -3,7 +3,7 @@ class GeocodeUserJob < ApplicationJob
 
   def perform(auth0_uid, access_token = nil)
     return unless auth0_uid
-    return unless Geocoder.config[:ipstack][:api_key]
+    return if Geocoder.config[:ipstack][:api_key].blank?
 
     user = User.find_by(auth0_uid: auth0_uid)
     return unless user

--- a/backend/spec/jobs/geocode_user_job_spec.rb
+++ b/backend/spec/jobs/geocode_user_job_spec.rb
@@ -18,8 +18,13 @@ RSpec.describe GeocodeUserJob, type: :job do
     let(:auth0_uid) { 'whatever' }
     before { create(:user, auth0_uid: auth0_uid) } # now we would run into a request
 
-    context 'missing' do
+    context 'nil' do
       before { allow(Geocoder.config).to receive(:[]).with(:ipstack).and_return(api_key: nil) }
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'blank' do
+      before { allow(Geocoder.config).to receive(:[]).with(:ipstack).and_return(api_key: '') }
       it { expect { subject }.not_to raise_error }
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Another attempt to fix #882 

#### Motivation and Context
In a previous PR #881 I made an error and thought the `api_key` would be `nil` if not set. Instead it's set to empty string and therefore bypassing the guard clause.

#### How Has This Been Tested?
I ran `docker-compose up --build` and debugged the `sidekiq` service with `binding.pry`. You can read here how to attach to docker containers: https://gist.github.com/briankung/ebfb567d149209d2d308576a6a34e5d8


#### Screenshots (if appropriate):

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes. -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
