### PR TITLE
Fix validation and translation errors on broadcast creation.

### DIFF
--- a/backend/app/models/broadcast.rb
+++ b/backend/app/models/broadcast.rb
@@ -14,7 +14,7 @@ class Broadcast < ApplicationRecord
 
   has_many :impressions, dependent: :destroy
 
-  before_validation :normalize_url, on: [:create, :update]
+  before_validation :normalize_url, on: %i[create update]
 
   paginates_per 10
   belongs_to :topic, optional: true

--- a/backend/app/models/broadcast.rb
+++ b/backend/app/models/broadcast.rb
@@ -14,6 +14,8 @@ class Broadcast < ApplicationRecord
 
   has_many :impressions, dependent: :destroy
 
+  before_validation :normalize_url, on: [:create, :update]
+
   paginates_per 10
   belongs_to :topic, optional: true
   belongs_to :format, optional: true
@@ -89,6 +91,11 @@ class Broadcast < ApplicationRecord
   end
 
   private
+
+  def normalize_url
+    self.broadcast_url = nil if broadcast_url.blank?
+    self.image_url = nil if image_url.blank?
+  end
 
   def description_should_not_contain_urls
     return unless description

--- a/backend/config/locales/de.yml
+++ b/backend/config/locales/de.yml
@@ -13,13 +13,12 @@ de:
           attributes:
             description:
               no_urls: am besten ohne Links. Man soll eine Sendung ja bewerten können auch ohne diese Website zu verlassen.
-            image_url:
-              invalid_url: Die hinzugefügte URL ist keine gültige URL!
         impression:
           attributes:
             amount:
               total: Die Summe von %{sum} übersteigt das verfügbare Budget von %{budget}
       messages:
+        invalid_url: Die hinzugefügte URL ist keine gültige URL!
         record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
         restrict_dependent_destroy:
           has_one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -2,15 +2,13 @@
 en:
   activerecord:
     errors:
+      messages:
+        invalid_url: added URL is not a valid URL!
       models:
         broadcast:
           attributes:
             description:
               no_urls: without links, please. Users should be able to view a broadcast without leaving this website.
-            image_url:
-              invalid_url: added URL is not a valid URL!
-            broadcast_url:
-              invalid_url: added URL is not a valid URL!
         impression:
           attributes:
             amount:

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -9,6 +9,8 @@ en:
               no_urls: without links, please. Users should be able to view a broadcast without leaving this website.
             image_url:
               invalid_url: added URL is not a valid URL!
+            broadcast_url:
+              invalid_url: added URL is not a valid URL!
         impression:
           attributes:
             amount:

--- a/backend/spec/models/broadcast_spec.rb
+++ b/backend/spec/models/broadcast_spec.rb
@@ -317,8 +317,8 @@ RSpec.describe Broadcast, type: :model do
     end
 
     describe 'empty image_url' do
-      let(:broadcast) { build(:broadcast, image_url: ' ') }
-      it { is_expected.to_not be_valid }
+      let(:broadcast) { create(:broadcast, image_url: ' ') }
+      it { expect(broadcast.image_url).to eq(nil) }
     end
 
     describe 'image_url' do
@@ -339,8 +339,8 @@ RSpec.describe Broadcast, type: :model do
     end
 
     describe 'empty broadcast_url' do
-      let(:broadcast) { build(:broadcast, broadcast_url: ' ') }
-      it { is_expected.to_not be_valid }
+      let(:broadcast) { create(:broadcast, broadcast_url: ' ') }
+      it { expect(broadcast.broadcast_url).to eq(nil) }
     end
 
     describe 'broadcast_url' do


### PR DESCRIPTION
An empty string should be nil before validation on the broadcast url and
image url. This is done because the presence of an empty string should
be valid and it is nullified in order to prevent broken links with empty
url's.

Fixes #862 