### PR TITLE
[WIP] Small results label

### DIFF
--- a/frontend/app/controllers/find-broadcasts.js
+++ b/frontend/app/controllers/find-broadcasts.js
@@ -23,6 +23,7 @@ export default Controller.extend({
   page: 1,
   perPage: 6,
   totalPages: alias("model.broadcasts.totalPages"),
+  totalCount: alias("model.broadcasts.meta.total-count"),
 
   positiveImpressionsWithoutAmount: filterBy('model.impressions','needsAmount', true),
 

--- a/frontend/app/templates/components/broadcast-search.hbs
+++ b/frontend/app/templates/components/broadcast-search.hbs
@@ -2,7 +2,7 @@
   <div class="ui sixteen wide column">
     <form {{action "search" on="submit"}} class="ui broadcast-search form">
       <div class="two fields">
-        <div class="field">
+        <div class="fourteen wide field">
           <div class="ui action fluid input">
             {{input id="search" value=filterParams.q class="prompt" type="text" placeholder=(t 'broadcast-search.query.placeholder') }}
             <button type="submit" id='submit-search' class="ui primary icon button {{if loading 'loading'}}">
@@ -10,9 +10,14 @@
             </button>
           </div>
         </div>
-        <div class="field">
-          <div class="ui big fluid label">
-            {{t 'broadcast-search.results' count=totalCount}}
+        <div class="two wide field">
+          <div class="ui mini right floated vertical statistic">
+            <div class="value">
+              {{totalCount}}
+            </div>
+            <div class="label">
+              {{t 'broadcast-search.results'}}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/app/templates/components/broadcast-search.hbs
+++ b/frontend/app/templates/components/broadcast-search.hbs
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="ui sixteen wide column">
     <form {{action "search" on="submit"}} class="ui broadcast-search form">
-      <div class="two fields">
-        <div class="fourteen wide field">
+      <div class="four fields">
+        <div class="six wide field">
           <div class="ui action fluid input">
             {{input id="search" value=filterParams.q class="prompt" type="text" placeholder=(t 'broadcast-search.query.placeholder') }}
             <button type="submit" id='submit-search' class="ui primary icon button {{if loading 'loading'}}">
@@ -10,19 +10,7 @@
             </button>
           </div>
         </div>
-        <div class="two wide field">
-          <div class="ui mini right floated vertical statistic">
-            <div class="value">
-              {{totalCount}}
-            </div>
-            <div class="label">
-              {{t 'broadcast-search.results'}}
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="three fields">
-        <div class="six wide field filter-media-field">
+        <div class="four wide field filter-media-field">
           {{#ui-dropdown class="fluid selection" selected='' onChange=(action 'filterMedium')}}
             <div class="default text">{{t 'broadcast-search.filter.medium.placeholder' }}</div>
             <i class="dropdown icon"></i>
@@ -36,7 +24,7 @@
             </div>
           {{/ui-dropdown}}
         </div>
-        <div class="six wide field filter-stations-field">
+        <div class="four wide field filter-stations-field">
           {{#if sortedStations}}
             {{#ui-dropdown class="fluid selection" selected='' onChange=(action 'filterStation')}}
               <div class="default text">{{t 'broadcast-search.filter.station.placeholder' }}</div>

--- a/frontend/app/templates/components/broadcast-search.hbs
+++ b/frontend/app/templates/components/broadcast-search.hbs
@@ -2,7 +2,7 @@
   <div class="ui sixteen wide column">
     <form {{action "search" on="submit"}} class="ui broadcast-search form">
       <div class="four fields">
-        <div class="six wide field">
+        <div class="five wide field">
           <div class="ui action fluid input">
             {{input id="search" value=filterParams.q class="prompt" type="text" placeholder=(t 'broadcast-search.query.placeholder') }}
             <button type="submit" id='submit-search' class="ui primary icon button {{if loading 'loading'}}">
@@ -34,7 +34,7 @@
                 {{#each sortedStations as |station|}}
                   <div class="item" data-value="{{station.id}}">
                     <span class="text">{{station.name}}</span>
-                    <span class="description">{{t 'broadcast-search.filter.station.description' count=station.broadcasts_count}}</span>
+                    <span class="description">#{{station.broadcasts_count}}</span>
                   </div>
                 {{/each}}
               </div>

--- a/frontend/app/templates/components/broadcast-sort.hbs
+++ b/frontend/app/templates/components/broadcast-sort.hbs
@@ -1,4 +1,4 @@
-<div class="four wide field">
+<div class="two wide field">
   <div class="ui right floated buttons">
     <button id="alphabetical_order_ascending" class="ui {{if (eq sort 'asc') 'active'}} icon button" {{action 'submitSort' 'asc'}}>
       <i class="sort alphabet ascending icon"></i>

--- a/frontend/app/templates/components/broadcast-sort.hbs
+++ b/frontend/app/templates/components/broadcast-sort.hbs
@@ -1,4 +1,4 @@
-<div class="two wide field">
+<div class="three wide field">
   <div class="ui right floated buttons">
     <button id="alphabetical_order_ascending" class="ui {{if (eq sort 'asc') 'active'}} icon button" {{action 'submitSort' 'asc'}}>
       <i class="sort alphabet ascending icon"></i>

--- a/frontend/app/templates/find-broadcasts.hbs
+++ b/frontend/app/templates/find-broadcasts.hbs
@@ -4,6 +4,8 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="column">
 {{broadcast-search
 searchAction=(action 'searchAction')
 broadcasts=model.broadcasts
@@ -11,6 +13,8 @@ media=media
 stations=stations
 filterParams=filterParams
 loading=loading}}
+</div>
+</div>
 
 <div class="row">
   <div class="column">

--- a/frontend/app/templates/find-broadcasts.hbs
+++ b/frontend/app/templates/find-broadcasts.hbs
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="column">
-    <h1 class="ui huge header find-broadcasts-page">{{t 'find-broadcasts.header'}} </h1>
+    <h1 class="ui huge header find-broadcasts-page">{{t 'find-broadcasts.header'}} ({{totalCount}})</h1>
   </div>
 </div>
 

--- a/frontend/app/templates/find-broadcasts.hbs
+++ b/frontend/app/templates/find-broadcasts.hbs
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="column">
-    <h1 class="ui huge header find-broadcasts-page">{{t 'find-broadcasts.header'}} ({{totalCount}})</h1>
+    <h1 class="ui huge header find-broadcasts-page">
+      {{t 'find-broadcasts.header'}}
+      {{totalCount}}
+      {{t 'find-broadcasts.header-end'}}
+    </h1>
   </div>
 </div>
 

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -307,7 +307,8 @@ broadcast:
       updatedAt: Zuletzt geändert am
       visit-broadcast: Zur Website der Sendung
 find-broadcasts:
-  header: Sendungen auswählen
+  header: Sendung suche. Jetzt
+  header-end: sendung gefunden.
   help-messages:
     missing-broadcast:
       header: Fehlt eine Sendung?

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -5,7 +5,6 @@ authentication:
 loading:
   message: Wird geladen...
 broadcast-search:
-  results: Sendungen
   query:
     placeholder: Sendungstitel, Beschreibung oder Sender
   filter:

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -5,7 +5,7 @@ authentication:
 loading:
   message: Wird geladen...
 broadcast-search:
-  results: '{count, plural, =0 {kein Ergebnis} =1 {# Ergebnis} other {# Ergebnisse }}'
+  results: Sendungen
   query:
     placeholder: Sendungstitel, Beschreibung oder Sender
   filter:

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -13,7 +13,6 @@ broadcast-search:
       placeholder: Filtern nach Medium
     station:
       placeholder: Nach Sendern filtern
-      description: '{count, plural, =1 {# Sendung} other {# Sendungen}}'
 broadcast-form:
   header:
     new: Neue Sendung

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -4,7 +4,7 @@ authentication:
 loading:
   message: Loading...
 broadcast-search:
-  results: '{count, plural, =0 {no result} =1 {# result} other {# results}}'
+  results: broadcasts
   query:
     placeholder: Broadcast title, description or station
   filter:

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -12,7 +12,6 @@ broadcast-search:
       placeholder: Filter by medium
     station:
       placeholder: Filter by station
-      description: '{count, plural, =1 {# broadcast} other {# broadcasts}}'
 broadcast-form:
   header:
     new: New broadcast

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -4,7 +4,6 @@ authentication:
 loading:
   message: Loading...
 broadcast-search:
-  results: broadcasts
   query:
     placeholder: Broadcast title, description or station
   filter:

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -289,7 +289,8 @@ broadcast:
       updatedAt: Last updated at
       visit-broadcast: Visit broadcast website
 find-broadcasts:
-  header: Choose broadcasts
+  header: Browse or filter broadcasts. Currently showing
+  header-end: broadcasts.
   help-messages:
     missing-broadcast:
       header: Something missing?


### PR DESCRIPTION
#### Description
This is an improvement of the filter+search menu on https://rundfunk-mitbestimmen.de/find-broadcasts. The label showing the number of results is way too big.
 
#### Motivation and Context
Make the menu smaller and less cluttered.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->



#### Screenshots (if appropriate):

Before:
![screenshot 28](https://user-images.githubusercontent.com/2110676/52369886-ec7f6400-2a51-11e9-93ec-98d643e83b65.png)

After:
![screenshot 27](https://user-images.githubusercontent.com/2110676/52369895-f1dcae80-2a51-11e9-9267-2a844a943a7a.png)
